### PR TITLE
feat(report): embed local demo video

### DIFF
--- a/appendices.html
+++ b/appendices.html
@@ -364,7 +364,7 @@ npm run package:offline:bundle</code></pre>
     <section id="monthly-videos">
       <h2>Monthly Videos</h2>
       <p>Monthly progress videos documenting the team's key findings and development progress throughout the project.</p>
-      <p><a href="https://liveuclac-my.sharepoint.com/:f:/g/personal/zcabmon_ucl_ac_uk/IgBcRus4405nTYYkNVr_8MFzAc511vnxC5TeXzkUpIfMwVw?e=Ojh6X6
+      <p><a href="https://liveuclac-my.sharepoint.com/:f:/g/personal/zcabmdt_ucl_ac_uk/IgAmjxL6fXiyQ64L63l-72kxAbzvqvqoKfjtUhpqSXFg32E?e=2wbyRG
 " target="_blank" rel="videos"> Onedrive Folder </a></p>
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -1264,73 +1264,44 @@ main img {
 
 .demo-poster {
   display: flex;
+  flex-direction: column;
   align-items: stretch;
+  gap: 0.75rem;
 }
 
-.demo-poster-screen {
+.demo-video-frame {
   position: relative;
   width: 100%;
-  min-height: 220px;
-  padding: 1.55rem;
+  aspect-ratio: 16 / 9;
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 22px;
   overflow: hidden;
-  background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.14), transparent 36%),
-    linear-gradient(155deg, #2f468a 0%, #5569b8 52%, #8ea4da 100%);
   box-shadow: 0 28px 54px -32px rgba(36, 61, 130, 0.58);
-  color: #fff;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  background: #111826;
 }
 
-.demo-poster-screen::before {
-  content: '';
-  position: absolute;
-  top: 1.35rem;
-  left: 1.45rem;
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
-}
-
-.demo-poster-screen::after {
-  content: '';
-  position: absolute;
-  top: 2.25rem;
-  left: 2.55rem;
-  width: 0;
-  height: 0;
-  border-top: 0.56rem solid transparent;
-  border-bottom: 0.56rem solid transparent;
-  border-left: 0.95rem solid rgba(255, 255, 255, 0.94);
-}
-
-.demo-poster-screen span {
-  display: inline-block;
-  margin-bottom: 0.35rem;
-  font-family: var(--font-code);
-  font-size: 0.76rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  opacity: 0.88;
-}
-
-.demo-poster-screen strong {
+.demo-video-player {
+  width: 100%;
+  height: 100%;
+  border: 0;
   display: block;
-  margin-bottom: 0.35rem;
-  color: #fff;
-  font-size: 1.55rem;
-  line-height: 1.15;
+  background: #111826;
 }
 
-.demo-poster-screen p {
-  margin-bottom: 0;
-  color: rgba(255, 255, 255, 0.84);
+.demo-link {
+  margin: 0;
+  font-size: 0.94rem;
+  color: var(--text-muted);
+}
+
+.demo-link a {
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.demo-link a:hover,
+.demo-link a:focus-visible {
+  text-decoration: underline;
 }
 
 .team-section-intro {

--- a/index.html
+++ b/index.html
@@ -114,12 +114,14 @@
           <h3>See SmolPC 2.0 across coding, office, image-editing, and 3D workflows</h3>
           <p>The final demo focuses on the shipped unified shell in <code>app/</code>, showing the shared startup flow, Code mode, Writer and Slides, GIMP, Blender, and the local-first runtime story behind them.</p>
         </div>
-        <div class="demo-poster" aria-hidden="true">
-          <div class="demo-poster-screen">
-            <span>Demo</span>
-            <strong>SmolPC 2.0</strong>
-            <p>Unified offline AI for education</p>
+        <div class="demo-poster">
+          <div class="demo-video-frame">
+            <video class="demo-video-player" controls preload="metadata">
+              <source src="assets/videos/SmolPC2.0-video-presentation.mp4" type="video/mp4">
+              Your browser does not support the video tag.
+            </video>
           </div>
+          <p class="demo-link"><a href="assets/videos/SmolPC2.0-video-presentation.mp4" target="_blank" rel="noopener noreferrer">Open the demo video directly</a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

This PR replaces the Home page demo placeholder/embed with the actual local project presentation video and updates the related appendix link.

## Changes

- embeds the local MP4 demo on the Home page using a native HTML video player
- adds the presentation file to `assets/videos/`
- updates the Home page backup link to open the local video directly
- keeps the existing responsive demo-card layout while simplifying the old YouTube-specific styling
- updates the appendix SharePoint/OneDrive link to the latest provided URL

## Notes

- This keeps the website aligned with the final submission format, where the report zip includes a separate video artefact.
- Unrelated local note files and `.DS_Store` files were not included.
